### PR TITLE
Better error handling for downloads

### DIFF
--- a/notebooks/blackmarblepy.ipynb
+++ b/notebooks/blackmarblepy.ipynb
@@ -113,7 +113,7 @@
     "    ```\n",
     "    \n",
     "    ```{caution}\n",
-    "    Please be aware that the \"Affiliation\" information on your [Earthdata profile](https://urs.earthdata.nasa.gov/profile/edit) is mandatory. Without this information, the [NASA Earthdata token](https://urs.earthdata.nasa.gov/documentation) will be invalid, which may result in an error (i.e., `OSError: Unable to synchronously open file (file signature not found)`)\n",
+    "    Please be aware that the \"Affiliation\" information on your [Earthdata profile](https://urs.earthdata.nasa.gov/profile/edit) is mandatory. Without this information, the [NASA Earthdata token](https://urs.earthdata.nasa.gov/documentation) will be invalid. In case of a download error, try visiting the URL which is failing, as you may be prompted to grant permissions.\n",
     "    \n",
     "    ![](../images/nasa_earthdata_affiliations.png)\n",
     "    ```\n",


### PR DESCRIPTION
# Pull Request Template

## Description

This adds better handling for data file downloads, and raises an error if an HTML response is detected rather than producing zero-size h5 files.

With my Earthdata account I had to visit one of the data file URLs and grant permissions before I could download the data. This change now makes this much more obvious, as it outputs the failing URL which you can visit in a browser and see what the issue is.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate)

## Additional context
